### PR TITLE
Fix compatibility with PG13.

### DIFF
--- a/collector.c
+++ b/collector.c
@@ -10,6 +10,9 @@
 #include "postgres.h"
 
 #include "catalog/pg_type.h"
+#if PG_VERSION_NUM >= 130000
+#include "common/hashfn.h"
+#endif
 #include "funcapi.h"
 #include "miscadmin.h"
 #include "postmaster/bgworker.h"


### PR DESCRIPTION
planner_hook now requires the input query_string, and tag_hash isn't
automatically available anymore with the existing includes.