### PR TITLE
Fix millisecond calculation for millisecs_diff()

### DIFF
--- a/collector.c
+++ b/collector.c
@@ -306,11 +306,11 @@ static int64
 millisecs_diff(TimestampTz tz1, TimestampTz tz2)
 {
 	long	secs;
-	int		millisecs;
+	int		microsecs;
 
-	TimestampDifference(tz1, tz2, &secs, &millisecs);
+	TimestampDifference(tz1, tz2, &secs, &microsecs);
 
-	return secs * 1000 + millisecs;
+	return secs * 1000 + microsecs / 1000;
 
 }
 


### PR DESCRIPTION
Hi, 

ISTM, millisecs_diff() did not return milliseconds correctly.
TimestampDifference() retrieves difference of  second and  *micro second*, so millisecs_diff() should be  return "secs * 1000 + microsecs / 1000;" rather than "secs * 1000 + millisecs";