### PR TITLE
Debian new upstream version compatible with PG13

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+pg-wait-sampling (1.1.2-1) unstable; urgency=medium
+
+  * New upstream version compatible with PG13
+
+ -- Adrien Nayrat <adrien.nayrat@anayrat.info>  Wed, 28 Oct 2020 09:03:03 +0000
+
 pg-wait-sampling (1.1.1-1) unstable; urgency=medium
 
   * Release 1.1.1

--- a/debian/control
+++ b/debian/control
@@ -4,9 +4,9 @@ Priority: optional
 Maintainer: Adrien Nayrat <adrien.nayrat@anayrat.info>
 Standards-Version: 4.5.0
 Build-Depends: debhelper (>=9~), postgresql-server-dev-all (>= 141~)
-Homepage: https://github.com/postgrespro/pg_wait-sampling
-Vcs-Browser: https://github.com/postgrespro/pg_wait-sampling
-Vcs-Git: https://github.com/postgrespro/pg_wait-sampling.git
+Homepage: https://github.com/postgrespro/pg_wait_sampling
+Vcs-Browser: https://github.com/postgrespro/pg_wait_sampling
+Vcs-Git: https://github.com/postgrespro/pg_wait_sampling.git
 
 Package: postgresql-9.6-pg-wait-sampling
 Architecture: any

--- a/debian/control
+++ b/debian/control
@@ -31,3 +31,9 @@ Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}, postgresql-12,
 Description: pg_wait-sampling provides functions for detailed per backend
  and per query statistics about PostgreSQL wait events
+
+Package: postgresql-13-pg-wait-sampling
+Architecture: any
+Depends: ${misc:Depends}, ${shlibs:Depends}, postgresql-13,
+Description: pg_wait-sampling provides functions for detailed per backend
+ and per query statistics about PostgreSQL wait events

--- a/debian/control.in
+++ b/debian/control.in
@@ -4,9 +4,9 @@ Priority: optional
 Maintainer: Adrien Nayrat <adrien.nayrat@anayrat.info>
 Standards-Version: 4.5.0
 Build-Depends: debhelper (>=9~), postgresql-server-dev-all (>= 141~)
-Homepage: https://github.com/postgrespro/pg_wait-sampling
-Vcs-Browser: https://github.com/postgrespro/pg_wait-sampling
-Vcs-Git: https://github.com/postgrespro/pg_wait-sampling.git
+Homepage: https://github.com/postgrespro/pg_wait_sampling
+Vcs-Browser: https://github.com/postgrespro/pg_wait_sampling
+Vcs-Git: https://github.com/postgrespro/pg_wait_sampling.git
 
 Package: postgresql-PGVERSION-pg-wait-sampling
 Architecture: any


### PR DESCRIPTION
Hello,

With the help of @rjuju , this PR fix a typo in project url and provide a new release needed for debian since postgres 13 (I received a report the build failed : http://qa-logs.debian.net/2020/10/27/pg-wait-sampling_1.1.1-1_unstable.log).
I think we also must tag a new release, I suggest 1.1.2.

cc @df7cb 