### PR TITLE
Fix the doc: profile_queries is "true" by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ GUCs.
 | pg_wait_sampling.history_period     | int4      | Period for history sampling in milliseconds |            10 |
 | pg_wait_sampling.profile_period     | int4      | Period for profile sampling in milliseconds |            10 |
 | pg_wait_sampling.profile_pid        | bool      | Whether profile should be per pid           |          true |
-| pg_wait_sampling.profile_queries    | bool      | Whether profile should be per query			|         false |
+| pg_wait_sampling.profile_queries    | bool      | Whether profile should be per query			|          true |
 
 If `pg_wait_sampling.profile_pid` is set to false, sampling profile wouldn't be
 collected in per-process manner.  In this case the value of pid could would


### PR DESCRIPTION
Noticed that `profile_queries` is `true` by default (and per https://github.com/postgrespro/pg_wait_sampling/blob/3feb2f98433afb8150d44a0bf8ffad047f89c20b/pg_wait_sampling.c#L193) – while README claims it's `false`.