### PR TITLE
[refer #PGPRO-6599]: Avoid race conditions while processing PROFILE_R…

### DIFF
--- a/collector.c
+++ b/collector.c
@@ -441,11 +441,12 @@ collector_main(Datum main_arg)
 		if (collector_hdr->request != NO_REQUEST)
 		{
 			LOCKTAG		tag;
-			SHMRequest	request = collector_hdr->request;
+			SHMRequest	request;
 
 			init_lock_tag(&tag, PGWS_COLLECTOR_LOCK);
 
 			LockAcquire(&tag, ExclusiveLock, false, false);
+			request = collector_hdr->request;
 			collector_hdr->request = NO_REQUEST;
 
 			if (request == HISTORY_REQUEST || request == PROFILE_REQUEST)

--- a/pg_wait_sampling.c
+++ b/pg_wait_sampling.c
@@ -594,13 +594,11 @@ receive_array(SHMRequest request, Size item_size, Size *count)
 	init_lock_tag(&queueTag, PGWS_QUEUE_LOCK);
 	LockAcquire(&queueTag, ExclusiveLock, false, false);
 
-	/* Ensure collector has processed previous request */
 	init_lock_tag(&collectorTag, PGWS_COLLECTOR_LOCK);
 	LockAcquire(&collectorTag, ExclusiveLock, false, false);
-	LockRelease(&collectorTag, ExclusiveLock, false);
-
 	recv_mq = shm_mq_create(collector_mq, COLLECTOR_QUEUE_SIZE);
 	collector_hdr->request = request;
+	LockRelease(&collectorTag, ExclusiveLock, false);
 
 	if (!collector_hdr->latch)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
@@ -770,9 +768,9 @@ pg_wait_sampling_reset_profile(PG_FUNCTION_ARGS)
 
 	init_lock_tag(&tagCollector, PGWS_COLLECTOR_LOCK);
 	LockAcquire(&tagCollector, ExclusiveLock, false, false);
+	collector_hdr->request = PROFILE_RESET;
 	LockRelease(&tagCollector, ExclusiveLock, false);
 
-	collector_hdr->request = PROFILE_RESET;
 	SetLatch(collector_hdr->latch);
 
 	LockRelease(&tag, ExclusiveLock, false);


### PR DESCRIPTION
…EQUEST and

PROFILE_RESET requests.

After initialization of "request" variable in collector.c main loop, another
client backend could change the value of "collector_hdr->request" variable.
Changing this value from "PROFILE_RESET" to "PROFILE_REQUEST" could cause
deadlock: "collector" processed "PROFILE_RESET" query while client backend
waits data from the "collector_mq" shared memory message queue. Now we read
and write "collector_hdr->request" variable only using "PGWS_COLLECTOR_LOCK"
lock.

Removed obsolete "read_current_wait()" function definition from
pg_wait_sampling.h.

tags: pg_wait_sampling