### PR TITLE
Add missing PGDLLEXPORT markings for collector_main function

### DIFF
--- a/pg_wait_sampling.h
+++ b/pg_wait_sampling.h
@@ -81,7 +81,7 @@ extern void init_lock_tag(LOCKTAG *tag, uint32 lock);
 /* collector.c */
 extern void register_wait_collector(void);
 extern void alloc_history(History *, int);
-extern void collector_main(Datum main_arg);
+PGDLLEXPORT extern void collector_main(Datum main_arg);
 
 extern void shm_mq_detach_compat(shm_mq_handle *mqh, shm_mq *mq);
 extern shm_mq_result shm_mq_send_compat(shm_mq_handle *mqh, Size nbytes,


### PR DESCRIPTION
After commit https://github.com/postgres/postgres/commit/089480c07, it's necessary for background worker entry points to be marked `PGDLLEXPORT`, else they aren't findable by `LookupBackgroundWorkerFunction()`.