### PR TITLE
Move all inlined compatible wrappers into header file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # contrib/pg_wait_sampling/Makefile
 
 MODULE_big = pg_wait_sampling
-OBJS = pg_wait_sampling.o collector.o compat.o
+OBJS = pg_wait_sampling.o collector.o
 
 EXTENSION = pg_wait_sampling
 EXTVERSION = 1.1

--- a/collector.c
+++ b/collector.c
@@ -26,6 +26,7 @@
 #include "utils/resowner.h"
 #include "pgstat.h"
 
+#include "compat.h"
 #include "pg_wait_sampling.h"
 
 static volatile sig_atomic_t shutdown_requested = false;

--- a/compat.h
+++ b/compat.h
@@ -1,11 +1,32 @@
+/*
+ * compat.h
+ *		Definitions for function wrappers compatible between PG versions.
+ *
+ * Copyright (c) 2015-2022, Postgres Professional
+ *
+ * IDENTIFICATION
+ *	  contrib/pg_wait_sampling/compat.h
+ */
+#ifndef __COMPAT_H__
+#define __COMPAT_H__
+
 #include "postgres.h"
 
 #include "access/tupdesc.h"
 #include "miscadmin.h"
+#include "storage/shm_mq.h"
 
-#include "pg_wait_sampling.h"
+static inline TupleDesc
+CreateTemplateTupleDescCompat(int nattrs, bool hasoid)
+{
+#if PG_VERSION_NUM >= 120000
+	return CreateTemplateTupleDesc(nattrs);
+#else
+	return CreateTemplateTupleDesc(nattrs, hasoid);
+#endif
+}
 
-inline void
+static inline void
 shm_mq_detach_compat(shm_mq_handle *mqh, shm_mq *mq)
 {
 #if PG_VERSION_NUM >= 100000
@@ -15,7 +36,7 @@ shm_mq_detach_compat(shm_mq_handle *mqh, shm_mq *mq)
 #endif
 }
 
-inline shm_mq_result
+static inline shm_mq_result
 shm_mq_send_compat(shm_mq_handle *mqh, Size nbytes, const void *data,
 				   bool nowait, bool force_flush)
 {
@@ -26,17 +47,7 @@ shm_mq_send_compat(shm_mq_handle *mqh, Size nbytes, const void *data,
 #endif
 }
 
-inline TupleDesc
-CreateTemplateTupleDescCompat(int nattrs, bool hasoid)
-{
-#if PG_VERSION_NUM >= 120000
-	return CreateTemplateTupleDesc(nattrs);
-#else
-	return CreateTemplateTupleDesc(nattrs, hasoid);
-#endif
-}
-
-inline void
+static inline void
 InitPostgresCompat(const char *in_dbname, Oid dboid,
 				   const char *username, Oid useroid,
 				   bool load_session_libraries,
@@ -53,3 +64,5 @@ InitPostgresCompat(const char *in_dbname, Oid dboid,
 	InitPostgres(in_dbname, dboid, username, useroid, out_dbname);
 #endif
 }
+
+#endif

--- a/pg_wait_sampling.c
+++ b/pg_wait_sampling.c
@@ -34,6 +34,7 @@
 #include "utils/memutils.h" /* TopMemoryContext.  Actually for PG 9.6 only,
 							 * but there should be no harm for others. */
 
+#include "compat.h"
 #include "pg_wait_sampling.h"
 
 PG_MODULE_MAGIC;

--- a/pg_wait_sampling.h
+++ b/pg_wait_sampling.h
@@ -83,15 +83,4 @@ extern void register_wait_collector(void);
 extern void alloc_history(History *, int);
 extern PGDLLEXPORT void collector_main(Datum main_arg);
 
-extern void shm_mq_detach_compat(shm_mq_handle *mqh, shm_mq *mq);
-extern shm_mq_result shm_mq_send_compat(shm_mq_handle *mqh, Size nbytes,
-										const void *data, bool nowait,
-										bool force_flush);
-extern TupleDesc CreateTemplateTupleDescCompat(int nattrs, bool hasoid);
-extern void InitPostgresCompat(const char *in_dbname, Oid dboid,
-							   const char *username, Oid useroid,
-							   bool load_session_libraries,
-							   bool override_allow_connections,
-							   char *out_dbname);
-
 #endif


### PR DESCRIPTION
Current implementation segregated compatible inline function wrappers into separate .c file that prevented inlining of these functions into caller points in other modules. In current patch all these fuctions are moved to header file `compat.h` so that inlining works.

Resolve https://github.com/postgrespro/pg_wait_sampling/issues/45