### PR TITLE
Fix build due to changes in PostgreSQL 16

### DIFF
--- a/collector.c
+++ b/collector.c
@@ -470,7 +470,7 @@ pgws_collector_main(Datum main_arg)
 								send_profile(profile_hash, mqh);
 								break;
 							default:
-								AssertState(false);
+								Assert(false);
 						}
 						break;
 					case SHM_MQ_DETACHED:
@@ -480,7 +480,7 @@ pgws_collector_main(Datum main_arg)
 										"detached")));
 						break;
 					default:
-						AssertState(false);
+						Assert(false);
 				}
 				shm_mq_detach_compat(mqh, pgws_collector_mq);
 			}

--- a/compat.h
+++ b/compat.h
@@ -15,6 +15,7 @@
 #include "access/tupdesc.h"
 #include "miscadmin.h"
 #include "storage/shm_mq.h"
+#include "utils/guc_tables.h"
 
 static inline TupleDesc
 CreateTemplateTupleDescCompat(int nattrs, bool hasoid)
@@ -62,6 +63,20 @@ InitPostgresCompat(const char *in_dbname, Oid dboid,
 				 override_allow_connections);
 #else
 	InitPostgres(in_dbname, dboid, username, useroid, out_dbname);
+#endif
+}
+
+static inline void
+get_guc_variables_compat(struct config_generic ***vars, int *num_vars)
+{
+	Assert(vars != NULL);
+	Assert(num_vars != NULL);
+
+#if PG_VERSION_NUM >= 160000
+	*vars = get_guc_variables(num_vars);
+#else
+	*vars = get_guc_variables();
+	*num_vars = GetNumConfigOptions();
 #endif
 }
 

--- a/pg_wait_sampling.c
+++ b/pg_wait_sampling.c
@@ -451,7 +451,6 @@ pg_wait_sampling_get_current(PG_FUNCTION_ARGS)
 	{
 		MemoryContext		oldcontext;
 		TupleDesc			tupdesc;
-		WaitCurrentContext 	*params;
 
 		funcctx = SRF_FIRSTCALL_INIT();
 

--- a/pg_wait_sampling.c
+++ b/pg_wait_sampling.c
@@ -198,8 +198,7 @@ setup_gucs()
 				profile_pid_found = false,
 				profile_queries_found = false;
 
-	guc_vars = get_guc_variables();
-	numOpts = GetNumConfigOptions();
+	get_guc_variables_compat(&guc_vars, &numOpts);
 
 	for (i = 0; i < numOpts; i++)
 	{


### PR DESCRIPTION
1. See the commit 3057465acfbea2f3dd7a914a1478064022c6eecd (Replace the sorted
array of GUC variables with a hash table.) in PostgreSQL 16.

2. See the commit 0fe954c28584169938e5c0738cfaa9930ce77577 (Add
-Wshadow=compatible-local to the standard compilation flags) in PostgreSQL 16.

```
pg_wait_sampling.c: In function ‘pg_wait_sampling_get_current’:
pg_wait_sampling.c:454:42: warning: declaration of ‘params’ shadows a previous
local [-Wshadow=compatible-local]
  454 |                 WaitCurrentContext      *params;
      |                                          ^~~~~~
pg_wait_sampling.c:446:34: note: shadowed declaration is here
  446 |         WaitCurrentContext      *params;
      |                                  ^~~~~~
```