### PR TITLE
Keep profile and history data in shared memory

### DIFF
--- a/collector.c
+++ b/collector.c
@@ -120,7 +120,16 @@ probe_waits(const bool write_history, const bool write_profile)
 	if (write_history)
 		LWLockAcquire(pgws_history_lock, LW_EXCLUSIVE);
 
-	/* Iterate PGPROCs under shared lock */
+	/*
+	 * Iterate PGPROCs under shared lock.
+	 *
+	 * TODO:
+	 * ProcArrayLock is heavy enough and in current case we might perform the
+	 * non-trivial deallocation routine for profile hash table under this lock.
+	 * Therefore to reduce possible contention it's worth to segregate the logic
+	 * of PGPROCs iteration under ProcArrayLock and storing results to profile
+	 * and/or history under corresponding another lock.
+	 */
 	LWLockAcquire(ProcArrayLock, LW_SHARED);
 	for (int i = 0; i < ProcGlobal->allProcCount; i++)
 	{

--- a/collector.c
+++ b/collector.c
@@ -324,12 +324,15 @@ pgws_collector_main(Datum main_arg)
 			HistoryPeriod - (int) history_diff : 0;
 		profile_timeout = ProfilePeriod >= (int) profile_diff ?
 			ProfilePeriod - (int) profile_diff : 0;
+
+		actual_timeout = 0;
 		if (ProfilePeriod && !HistoryPeriod)
 			actual_timeout = profile_timeout;
 		else if (HistoryPeriod && !ProfilePeriod)
 			actual_timeout = history_timeout;
 		else if (HistoryPeriod && ProfilePeriod)
 			actual_timeout = Min(history_timeout, profile_timeout);
+
 		rc = WaitLatchCompat(MyLatch,
 				WL_LATCH_SET | WL_POSTMASTER_DEATH |
 					(HistoryPeriod || ProfilePeriod ? WL_TIMEOUT : 0),

--- a/pg_wait_sampling.c
+++ b/pg_wait_sampling.c
@@ -140,7 +140,7 @@ pgws_shmem_size(void)
 
 	size = add_size(size, sizeof(pgwsQueryId) * get_max_procs_count());
 	size = add_size(size, hash_estimate_size(MaxProfileEntries,
-											 sizeof(ProfileHashKey)));
+											 sizeof(ProfileHashEntry)));
 	size = add_size(size,
 					sizeof(History) + sizeof(HistoryItem) * HistoryBufferSize);
 

--- a/pg_wait_sampling.h
+++ b/pg_wait_sampling.h
@@ -17,67 +17,60 @@
 	#error "You are trying to build pg_wait_sampling with PostgreSQL version lower than 9.6.  Please, check you environment."
 #endif
 
-#include "storage/proc.h"
-#include "storage/shm_mq.h"
 #include "utils/timestamp.h"
 
 #define	PG_WAIT_SAMPLING_MAGIC		0xCA94B107
-#define COLLECTOR_QUEUE_SIZE		(16 * 1024)
-#define HISTORY_TIME_MULTIPLIER		10
-#define PGWS_QUEUE_LOCK				0
-#define PGWS_COLLECTOR_LOCK			1
 
 typedef struct
 {
 	uint32			pid;
 	uint32			wait_event_info;
-	uint64			queryId;
-	uint64			count;
-} ProfileItem;
-
-typedef struct
-{
-	uint32			pid;
-	uint32			wait_event_info;
-	uint64			queryId;
+	pgwsQueryId		queryId;
 	TimestampTz		ts;
 } HistoryItem;
 
 typedef struct
 {
-	bool			wraparound;
-	Size			index;
-	Size			count;
-	HistoryItem	   *items;
+	Size		index;
+	HistoryItem	items[FLEXIBLE_ARRAY_MEMBER];
 } History;
 
-typedef enum
-{
-	NO_REQUEST,
-	HISTORY_REQUEST,
-	PROFILE_REQUEST,
-	PROFILE_RESET
-} SHMRequest;
-
+/*
+ * Hashtable key that defines the identity of a hashtable entry
+ */
 typedef struct
 {
-	Latch		   *latch;
-	SHMRequest		request;
-	int				historySize;
-	int				historyPeriod;
-	int				profilePeriod;
-	bool			profilePid;
-	bool			profileQueries;
-} CollectorShmqHeader;
+	int32		pid;			/* pid of observable process */
+	uint32		wait_event_info;/* proc's wait information */
+	pgwsQueryId	queryid;		/* query identifier */
+} ProfileHashKey;
+
+/*
+ * Wait statistics entry
+ */
+typedef struct
+{
+	ProfileHashKey	key;		/* hash key of entry - MUST BE FIRST */
+	int64			counter;	/* cummulative counter for this entry */
+	double			usage;		/* usage factor */
+} ProfileHashEntry;
 
 /* pg_wait_sampling.c */
-extern CollectorShmqHeader *pgws_collector_hdr;
-extern shm_mq			   *pgws_collector_mq;
-extern uint64			   *pgws_proc_queryids;
-extern void pgws_init_lock_tag(LOCKTAG *tag, uint32 lock);
+extern pgwsQueryId	*pgws_proc_queryids;
+extern HTAB 		*pgws_hash;
+extern LWLock 		*pgws_hash_lock;
+extern History		*pgws_history_ring;
+extern LWLock		*pgws_history_lock;
+
+/* global settings */
+extern int MaxProfileEntries;
+extern int HistoryBufferSize;
+extern int HistoryPeriod;
+extern int ProfilePeriod;
+extern bool WhetherProfilePid;
+extern bool WhetherProfileQueryId;
 
 /* collector.c */
-extern void pgws_register_wait_collector(void);
 extern PGDLLEXPORT void pgws_collector_main(Datum main_arg);
 
 #endif

--- a/pg_wait_sampling.h
+++ b/pg_wait_sampling.h
@@ -57,8 +57,8 @@ typedef struct
 
 /* pg_wait_sampling.c */
 extern pgwsQueryId	*pgws_proc_queryids;
-extern HTAB 		*pgws_hash;
-extern LWLock 		*pgws_hash_lock;
+extern HTAB 		*pgws_profile_hash;
+extern LWLock 		*pgws_profile_lock;
 extern History		*pgws_history_ring;
 extern LWLock		*pgws_history_lock;
 


### PR DESCRIPTION
To simplify interaction between collector process and client backends requesting profile or history data the current patch adds shared data structures to store statistics: the fixed-size shared hash table to keep profile and fixed-size shared array to implement ring buffer for history data.
Shared hash table for profile has fixed size specified by `pg_wait_sampling.max_profile_entries` GUC. The least used entries are diplaced from hash table when its overflow encounters. The eviction algorithm is the same that is [used](https://github.com/powa-team/pg_stat_kcache/blob/d0ebd3f087bf25582076dab2e6eef0f6ddea988c/pg_stat_kcache.c#L833-L872) in pg_stat_kcache extension - it's based on usage metric stored within hash table entries.
The shared structures for profile and history are solely in-memory and not persisted to external disk. So after server restart all statistics fully reset. This is not bad because for wait monitoring it's enough to keep track differential counters in profile statistics.

Current patch also makes all timing period GUCs reloadable via SIGHUP. Other GUCs in some way have impact on allocation of shared resources so they are done changable via server restart.

The history keeping looks not usable for regular monitoring of wait events so in current patch it's disabled by default by specifying zero value for `pg_wait_sampling.history_period` GUC.