### PR TITLE
Track on CPU events too

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ be always zero and corresponding row contain samples among all the processes.
 While `pg_wait_sampling.profile_queries` is set to false `queryid` field in
 views will be zero.
 
-If `pg_wait_sampling.sample_cpu` is set to true hen processes that are not
+If `pg_wait_sampling.sample_cpu` is set to true then processes that are not
 waiting on anything are also sampled. The wait event columns for such processes
 will be NULL.
 

--- a/README.md
+++ b/README.md
@@ -133,13 +133,14 @@ in-memory hash table.
 The work of wait event statistics collector worker is controlled by following
 GUCs.
 
-|         Parameter name              | Data type |                  Description                | Default value |
-| ----------------------------------- | --------- | ------------------------------------------- | ------------: |
-| pg_wait_sampling.history_size       | int4      | Size of history in-memory ring buffer       |          5000 |
-| pg_wait_sampling.history_period     | int4      | Period for history sampling in milliseconds |            10 |
-| pg_wait_sampling.profile_period     | int4      | Period for profile sampling in milliseconds |            10 |
-| pg_wait_sampling.profile_pid        | bool      | Whether profile should be per pid           |          true |
-| pg_wait_sampling.profile_queries    | bool      | Whether profile should be per query			|          true |
+| Parameter name                   | Data type | Description                                 | Default value |
+|----------------------------------| --------- |---------------------------------------------|--------------:|
+| pg_wait_sampling.history_size    | int4      | Size of history in-memory ring buffer       |          5000 |
+| pg_wait_sampling.history_period  | int4      | Period for history sampling in milliseconds |            10 |
+| pg_wait_sampling.profile_period  | int4      | Period for profile sampling in milliseconds |            10 |
+| pg_wait_sampling.profile_pid     | bool      | Whether profile should be per pid           |          true |
+| pg_wait_sampling.profile_queries | bool      | Whether profile should be per query         |          true |
+| pg_wait_sampling.sample_cpu      | bool      | Whether on CPU backends should be sampled   |         false |
 
 If `pg_wait_sampling.profile_pid` is set to false, sampling profile wouldn't be
 collected in per-process manner.  In this case the value of pid could would
@@ -147,6 +148,10 @@ be always zero and corresponding row contain samples among all the processes.
 
 While `pg_wait_sampling.profile_queries` is set to false `queryid` field in
 views will be zero.
+
+If `pg_wait_sampling.sample_cpu` is set to true hen processes that are not
+waiting on anything are also sampled. The wait event columns for such processes
+will be NULL.
 
 These GUCs are allowed to be changed by superuser.  Also, they are placed into
 shared memory.  Thus, they could be changed from any backend and affects worker

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ GUCs.
 | pg_wait_sampling.profile_period  | int4      | Period for profile sampling in milliseconds |            10 |
 | pg_wait_sampling.profile_pid     | bool      | Whether profile should be per pid           |          true |
 | pg_wait_sampling.profile_queries | bool      | Whether profile should be per query         |          true |
-| pg_wait_sampling.sample_cpu      | bool      | Whether on CPU backends should be sampled   |         false |
+| pg_wait_sampling.sample_cpu      | bool      | Whether on CPU backends should be sampled   |          true |
 
 If `pg_wait_sampling.profile_pid` is set to false, sampling profile wouldn't be
 collected in per-process manner.  In this case the value of pid could would

--- a/collector.c
+++ b/collector.c
@@ -163,6 +163,9 @@ probe_waits(History *observations, HTAB *profile_hash,
 					   *observation;
 		PGPROC		   *proc = &ProcGlobal->allProcs[i];
 
+		if (proc->wait_event_info == 0 && !pgws_collector_hdr->sampleCpu)
+			continue;
+
 		if (proc->pid == 0 || proc->procLatch.owner_pid == 0 || proc->pid == MyProcPid)
 			continue;
 

--- a/collector.c
+++ b/collector.c
@@ -163,10 +163,7 @@ probe_waits(History *observations, HTAB *profile_hash,
 					   *observation;
 		PGPROC		   *proc = &ProcGlobal->allProcs[i];
 
-		if (proc->pid == 0)
-			continue;
-
-		if (proc->wait_event_info == 0)
+		if (proc->pid == 0 || proc->procLatch.owner_pid == 0 || proc->pid == MyProcPid)
 			continue;
 
 		/* Collect next wait event sample */

--- a/collector.c
+++ b/collector.c
@@ -166,6 +166,12 @@ probe_waits(History *observations, HTAB *profile_hash,
 		if (proc->wait_event_info == 0 && !pgws_collector_hdr->sampleCpu)
 			continue;
 
+		/*
+		 * On PostgreSQL versions < 17 the PGPROC->pid field is not reset on
+		 * process exit. This would lead to such processes getting counted
+		 * for null wait events. So instead we make use of DisownLatch()
+		 * resetting owner_pid during ProcKill().
+		 */
 		if (proc->pid == 0 || proc->procLatch.owner_pid == 0 || proc->pid == MyProcPid)
 			continue;
 

--- a/collector.c
+++ b/collector.c
@@ -163,16 +163,7 @@ probe_waits(History *observations, HTAB *profile_hash,
 					   *observation;
 		PGPROC		   *proc = &ProcGlobal->allProcs[i];
 
-		if (proc->wait_event_info == 0 && !pgws_collector_hdr->sampleCpu)
-			continue;
-
-		/*
-		 * On PostgreSQL versions < 17 the PGPROC->pid field is not reset on
-		 * process exit. This would lead to such processes getting counted
-		 * for null wait events. So instead we make use of DisownLatch()
-		 * resetting owner_pid during ProcKill().
-		 */
-		if (proc->pid == 0 || proc->procLatch.owner_pid == 0 || proc->pid == MyProcPid)
+		if (!pgws_should_sample_proc(proc))
 			continue;
 
 		/* Collect next wait event sample */

--- a/pg_wait_sampling.c
+++ b/pg_wait_sampling.c
@@ -245,7 +245,7 @@ setup_gucs()
 		{
 			sample_cpu_found = true;
 			var->_bool.variable = &pgws_collector_hdr->sampleCpu;
-			pgws_collector_hdr->sampleCpu = false;
+			pgws_collector_hdr->sampleCpu = true;
 		}
 	}
 
@@ -282,7 +282,7 @@ setup_gucs()
 	if (!sample_cpu_found)
 		DefineCustomBoolVariable("pg_wait_sampling.sample_cpu",
 		                         "Sets whether not waiting backends should be sampled.", NULL,
-		                         &pgws_collector_hdr->sampleCpu, false,
+		                         &pgws_collector_hdr->sampleCpu, true,
 		                         PGC_SUSET, 0, shmem_bool_guc_check_hook, NULL, NULL);
 
 	if (history_size_found

--- a/pg_wait_sampling.h
+++ b/pg_wait_sampling.h
@@ -76,6 +76,7 @@ extern CollectorShmqHeader *pgws_collector_hdr;
 extern shm_mq			   *pgws_collector_mq;
 extern uint64			   *pgws_proc_queryids;
 extern void pgws_init_lock_tag(LOCKTAG *tag, uint32 lock);
+extern bool pgws_should_sample_proc(PGPROC *proc);
 
 /* collector.c */
 extern void pgws_register_wait_collector(void);

--- a/pg_wait_sampling.h
+++ b/pg_wait_sampling.h
@@ -68,6 +68,7 @@ typedef struct
 	int				profilePeriod;
 	bool			profilePid;
 	bool			profileQueries;
+	bool			sampleCpu;
 } CollectorShmqHeader;
 
 /* pg_wait_sampling.c */


### PR DESCRIPTION
To not count dead backends as still running on the CPU we need to detect that the backend is dead. Starting from PG17 proc->pid is reset in ProcKill, before this we can check if the process latch is disowned. Not nice to be poking around in latch internals like this, but all alternatives seem to involve scanning bestatus array and correlating pids.

Verified that the latch disown mechanism works on at least PostgreSQL 12-16.

Also makes sense to exclude ourselves as we will always be on CPU while looking at wait events.

Resolves #10 