### PR TITLE
Store GUC variables in local process memory to avoid IPC shenanigans

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ If `pg_wait_sampling.sample_cpu` is set to true then processes that are not
 waiting on anything are also sampled. The wait event columns for such processes
 will be NULL.
 
-These GUCs are allowed to be changed by superuser.  Also, they are placed into
-shared memory.  Thus, they could be changed from any backend and affects worker
-runtime.
+Values of these GUC variables can be changed only in config file or with ALTER SYSTEM.
+Then you need to reload server's configuration (such as with pg_reload_conf function)
+for changes to take effect.
 
 See
 [PostgreSQL documentation](http://www.postgresql.org/docs/devel/static/monitoring-stats.html#WAIT-EVENT-TABLE)

--- a/compat.h
+++ b/compat.h
@@ -51,18 +51,4 @@ InitPostgresCompat(const char *in_dbname, Oid dboid,
 #endif
 }
 
-static inline void
-get_guc_variables_compat(struct config_generic ***vars, int *num_vars)
-{
-	Assert(vars != NULL);
-	Assert(num_vars != NULL);
-
-#if PG_VERSION_NUM >= 160000
-	*vars = get_guc_variables(num_vars);
-#else
-	*vars = get_guc_variables();
-	*num_vars = GetNumConfigOptions();
-#endif
-}
-
 #endif

--- a/pg_wait_sampling.h
+++ b/pg_wait_sampling.h
@@ -58,13 +58,15 @@ typedef struct
 {
 	Latch		   *latch;
 	SHMRequest		request;
-	int				historySize;
-	int				historyPeriod;
-	int				profilePeriod;
-	bool			profilePid;
-	int				profileQueries;
-	bool			sampleCpu;
 } CollectorShmqHeader;
+
+/* GUC variables */
+extern int pgws_historySize;
+extern int pgws_historyPeriod;
+extern int pgws_profilePeriod;
+extern bool pgws_profilePid;
+extern int pgws_profileQueries;
+extern bool pgws_sampleCpu;
 
 /* pg_wait_sampling.c */
 extern CollectorShmqHeader *pgws_collector_hdr;


### PR DESCRIPTION
For more context and reasoning see issue #85