### PR TITLE
Check collector has started in pg_wait_sampling_reset_profile.

### DIFF
--- a/pg_wait_sampling.c
+++ b/pg_wait_sampling.c
@@ -649,6 +649,10 @@ receive_array(SHMRequest request, Size item_size, Size *count)
 	pgws_collector_hdr->request = request;
 	LockRelease(&collectorTag, ExclusiveLock, false);
 
+        /*
+         * Check that the collector was started to avoid NULL
+         * pointer dereference.
+         */
 	if (!pgws_collector_hdr->latch)
 		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 						errmsg("pg_wait_sampling collector wasn't started")));
@@ -818,6 +822,14 @@ pg_wait_sampling_reset_profile(PG_FUNCTION_ARGS)
 	LockAcquire(&collectorTag, ExclusiveLock, false, false);
 	pgws_collector_hdr->request = PROFILE_RESET;
 	LockRelease(&collectorTag, ExclusiveLock, false);
+
+        /*
+         * Check that the collector was started to avoid NULL
+         * pointer dereference.
+         */
+	if (!pgws_collector_hdr->latch)
+		ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
+						errmsg("pg_wait_sampling collector wasn't started")));
 
 	SetLatch(pgws_collector_hdr->latch);
 


### PR DESCRIPTION
The worker might have not started yet or it may never start, because its registration was cancelled due to worker limit.

This commit adds a check for NULL value of pgws_collector_hdr->latch. The previous usage in pg_wait_sampling.c has such a check, we should do the same here.