### PR TITLE
Code should be stable to the struct LOCKTAG extension.

### DIFF
--- a/pg_wait_sampling.c
+++ b/pg_wait_sampling.c
@@ -622,6 +622,7 @@ typedef struct
 void
 pgws_init_lock_tag(LOCKTAG *tag, uint32 lock)
 {
+	memset(tag, 0, sizeof(LOCKTAG));
 	tag->locktag_field1 = PG_WAIT_SAMPLING_MAGIC;
 	tag->locktag_field2 = lock;
 	tag->locktag_field3 = 0;


### PR DESCRIPTION
LOCKTAG is used in hash calculations, so if new field is added to LOCKTAG and this field is not initialized in pg_wait_sampling internals, as the result, the hashcode of LOCKTAG will have different values for two independent calculations.