### PR TITLE
Fix -Wpointer-arith compile warning

### DIFF
--- a/pg_wait_sampling.c
+++ b/pg_wait_sampling.c
@@ -638,9 +638,9 @@ receive_array(SHMRequest request, Size item_size, Size *count)
 	shm_mq_result res;
 	Size		len,
 				i;
-	void	   *data;
-	Pointer		result,
-				ptr;
+	void	   *data,
+			   *result;
+	char	   *ptr;
 	MemoryContext oldctx;
 
 	/* Ensure nobody else trying to send request to queue */


### PR DESCRIPTION
I've fixed the below compile warning.

```
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wshadow=compatible-local -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation -g -O0 -fPIC -fvisibility=hidden -I. -I./ -I/home/shinya/pgsql/poc-syncrepqueue-to-hash/include/server -I/home/shinya/pgsql/poc-syncrepqueue-to-hash/include/internal -D_GNU_SOURCE      -c -o pg_wait_sampling.o pg_wait_sampling.c
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wshadow=compatible-local -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation -g -O0 -fPIC -fvisibility=hidden -I. -I./ -I/home/shinya/pgsql/poc-syncrepqueue-to-hash/include/server -I/home/shinya/pgsql/poc-syncrepqueue-to-hash/include/internal -D_GNU_SOURCE      -c -o collector.o collector.c
pg_wait_sampling.c: In function ‘receive_array’:
pg_wait_sampling.c:707:29: warning: pointer of type ‘void *’ used in arithmetic [-Wpointer-arith]
  707 |                         ptr += item_size;
      |                             ^~
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcast-function-type -Wshadow=compatible-local -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation -g -O0 -fPIC -fvisibility=hidden -shared -o pg_wait_sampling.so pg_wait_sampling.o collector.o -L/home/shinya/pgsql/poc-syncrepqueue-to-hash/lib    -Wl,--as-needed -Wl,-rpath,'/home/shinya/pgsql/poc-syncrepqueue-to-hash/lib',--enable-new-dtags -fvisibility=hidden
```