### PR TITLE
Fix compatibility with pg19

### DIFF
--- a/pg_wait_sampling.c
+++ b/pg_wait_sampling.c
@@ -32,6 +32,9 @@
 #include "utils/guc.h"
 #include "utils/memutils.h"
 #include "utils/timestamp.h"
+#if PG_VERSION_NUM >= 190000
+#include "utils/wait_event.h"
+#endif
 
 #if PG_VERSION_NUM < 150000
 #include "postmaster/autovacuum.h"


### PR DESCRIPTION
Commit postgres/postgres@868825a removed include wait_event.h from pgstat.h.
Include it manually.